### PR TITLE
remove match::simple from recommends

### DIFF
--- a/meta/makefile.pret
+++ b/meta/makefile.pret
@@ -4,7 +4,6 @@
 
 `match-simple-XS`
 	:runtime-requirement    [ :on "perl 5.008"^^:CpanId ];
-	:runtime-recommendation [ :on "match::simple"^^:CpanId ];
 	:test-requirement       [ :on "Test::More 0.96"^^:CpanId ];
 	:test-requirement       [ :on "Test::Fatal"^^:CpanId ];
 	:develop-recommendation [ :on "Dist::Inkt 0.001"^^:CpanId ];


### PR DESCRIPTION
match::simple isn't needed directly by anything in this dist.  It's
unlikely anyone would be installing this module to try to get
match::simple rather than the other way around.  Also, if the user wants
to install recommends, it introduces circular dependencies between the
two modules.